### PR TITLE
Prevent other actions when robot is not placed + change to tests

### DIFF
--- a/app/factories/command_factory.rb
+++ b/app/factories/command_factory.rb
@@ -15,19 +15,15 @@ class CommandFactory
   end
 
   def parse(input)
-    command = nil
-
     case input
     when PLACE_COMMAND_PATTERN then
       # destructuring array into variables: X, Y, facing direction
       _input, x, y, facing = input.match(PLACE_COMMAND_PATTERN).to_a
-      command = PlaceCommand.new(@table, @robot, Position.new(x.to_i, y.to_i, facing))
-    when 'MOVE' then command = MoveCommand.new(@table, @robot)
-    when 'LEFT' then command = LeftCommand.new(@robot)
-    when 'RIGHT' then command = RightCommand.new(@robot)
-    when 'REPORT' then command = ReportCommand.new(@robot)
+      PlaceCommand.new(@table, @robot, Position.new(x.to_i, y.to_i, facing))
+    when 'MOVE' then MoveCommand.new(@table, @robot)
+    when 'LEFT' then LeftCommand.new(@robot)
+    when 'RIGHT' then RightCommand.new(@robot)
+    when 'REPORT' then ReportCommand.new(@robot)
     end
-
-    command
   end
 end

--- a/app/models/report_command.rb
+++ b/app/models/report_command.rb
@@ -5,6 +5,8 @@ class ReportCommand
   end
 
   def execute
+    return unless @robot.placed?
+
     puts @robot.report_position
   end
 end

--- a/test/test_left_command.rb
+++ b/test/test_left_command.rb
@@ -100,4 +100,12 @@ describe LeftCommand, '#execute' do
     _(actual).must_equal expected
   end
 
+  it 'return nil (ignore LeftCommand) if position is nothing' do
+    left_command = LeftCommand.new(@robot)
+
+    actual = left_command.execute
+
+    _(actual).must_be_nil
+  end
+
 end

--- a/test/test_left_command.rb
+++ b/test/test_left_command.rb
@@ -56,48 +56,52 @@ describe LeftCommand, '#execute' do
     _(actual).must_equal expected
   end
   
-  it 'turn 1 times to WEST when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    1.times { LeftCommand.new(@robot).execute }
+  describe 'turn multiple times' do
 
-    actual = @robot.report_position
-    expected = '1,1,WEST'
+    it 'turn 1 times to WEST when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      1.times { LeftCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
-  end
-  
-  it 'turn 2 times to SOUTH when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    2.times { LeftCommand.new(@robot).execute }
+      actual = @robot.report_position
+      expected = '1,1,WEST'
 
-    actual = @robot.report_position
-    expected = '1,1,SOUTH'
+      _(actual).must_equal expected
+    end
+    
+    it 'turn 2 times to SOUTH when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      2.times { LeftCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
-  end
-  
-  it 'turn 3 times to EAST when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    3.times { LeftCommand.new(@robot).execute }
+      actual = @robot.report_position
+      expected = '1,1,SOUTH'
 
-    actual = @robot.report_position
-    expected = '1,1,EAST'
+      _(actual).must_equal expected
+    end
+    
+    it 'turn 3 times to EAST when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      3.times { LeftCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
-  end
-  
-  it 'turn 4 times to NORTH when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    4.times { LeftCommand.new(@robot).execute }
+      actual = @robot.report_position
+      expected = '1,1,EAST'
 
-    actual = @robot.report_position
-    expected = '1,1,NORTH'
+      _(actual).must_equal expected
+    end
+    
+    it 'turn 4 times to NORTH when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      4.times { LeftCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
+      actual = @robot.report_position
+      expected = '1,1,NORTH'
+
+      _(actual).must_equal expected
+    end
+
   end
 
   it 'return nil (ignore LeftCommand) if position is nothing' do

--- a/test/test_move_command.rb
+++ b/test/test_move_command.rb
@@ -138,4 +138,11 @@ describe MoveCommand, '#execute valid cases' do
     _(actual).must_equal expected
   end
 
+  it 'return nil (ignore MoveCommand) if position is nothing' do
+    move_command = MoveCommand.new(@table, @robot)
+    
+    actual = move_command.execute
+
+    _(actual).must_be_nil
+  end
 end

--- a/test/test_report_command.rb
+++ b/test/test_report_command.rb
@@ -11,8 +11,7 @@ describe ReportCommand, '#execute' do
 
   it 'return position as text with a VALID position' do
     position = Position.new(1, 3, 'NORTH')
-    place_command = PlaceCommand.new(@table, @robot, position)
-    place_command.execute
+    PlaceCommand.new(@table, @robot, position).execute
 
     report_command = ReportCommand.new(@robot)
     expected = "1,3,NORTH\n"
@@ -20,13 +19,22 @@ describe ReportCommand, '#execute' do
     _{report_command.execute}.must_output expected
   end
 
-  it 'return "Not in place" with an INVALID position' do
+  it 'position does not change with an INVALID position' do
+    position = Position.new(1, 3, 'NORTH')
+    PlaceCommand.new(@table, @robot, position).execute
+
     invalid_position = Position.new(1, -3, 'NORTH')
-    place_command = PlaceCommand.new(@table, @robot, invalid_position)
-    place_command.execute
+    PlaceCommand.new(@table, @robot, invalid_position).execute
 
     report_command = ReportCommand.new(@robot)
-    expected = "Not in place\n"
+    expected = "1,3,NORTH\n"
+
+    _{report_command.execute}.must_output expected
+  end
+
+  it 'return nil (ignore ReportCommand) if position is nothing' do
+    report_command = ReportCommand.new(@robot)
+    expected = nil
 
     _{report_command.execute}.must_output expected
   end

--- a/test/test_report_command.rb
+++ b/test/test_report_command.rb
@@ -34,8 +34,9 @@ describe ReportCommand, '#execute' do
 
   it 'return nil (ignore ReportCommand) if position is nothing' do
     report_command = ReportCommand.new(@robot)
-    expected = nil
+    
+    actual = report_command.execute
 
-    _{report_command.execute}.must_output expected
+    _(actual).must_be_nil
   end
 end

--- a/test/test_right_command.rb
+++ b/test/test_right_command.rb
@@ -100,4 +100,11 @@ describe RightCommand, '#execute' do
     _(actual).must_equal expected
   end
 
+  it 'return nil (ignore RightCommand) if position is nothing' do
+    right_command = RightCommand.new(@robot)
+
+    actual = right_command.execute
+
+    _(actual).must_be_nil
+  end
 end

--- a/test/test_right_command.rb
+++ b/test/test_right_command.rb
@@ -56,48 +56,52 @@ describe RightCommand, '#execute' do
     _(actual).must_equal expected
   end
   
-  it 'turn 1 times to EAST when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    1.times { RightCommand.new(@robot).execute }
+  describe 'turn multiple times' do
 
-    actual = @robot.report_position
-    expected = '1,1,EAST'
+    it 'turn 1 times to EAST when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      1.times { RightCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
-  end
-  
-  it 'turn 2 times to SOUTH when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    2.times { RightCommand.new(@robot).execute }
+      actual = @robot.report_position
+      expected = '1,1,EAST'
 
-    actual = @robot.report_position
-    expected = '1,1,SOUTH'
+      _(actual).must_equal expected
+    end
+    
+    it 'turn 2 times to SOUTH when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      2.times { RightCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
-  end
-  
-  it 'turn 3 times to WEST when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    3.times { RightCommand.new(@robot).execute }
+      actual = @robot.report_position
+      expected = '1,1,SOUTH'
 
-    actual = @robot.report_position
-    expected = '1,1,WEST'
+      _(actual).must_equal expected
+    end
+    
+    it 'turn 3 times to WEST when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      3.times { RightCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
-  end
-  
-  it 'turn 4 times to NORTH when facing NORTH' do
-    position = Position.new(1, 1, 'NORTH')
-    PlaceCommand.new(@table, @robot, position).execute
-    4.times { RightCommand.new(@robot).execute }
+      actual = @robot.report_position
+      expected = '1,1,WEST'
 
-    actual = @robot.report_position
-    expected = '1,1,NORTH'
+      _(actual).must_equal expected
+    end
+    
+    it 'turn 4 times to NORTH when facing NORTH' do
+      position = Position.new(1, 1, 'NORTH')
+      PlaceCommand.new(@table, @robot, position).execute
+      4.times { RightCommand.new(@robot).execute }
 
-    _(actual).must_equal expected
+      actual = @robot.report_position
+      expected = '1,1,NORTH'
+
+      _(actual).must_equal expected
+    end
+
   end
 
   it 'return nil (ignore RightCommand) if position is nothing' do


### PR DESCRIPTION
CHANGED:
REPORT action
- ignore when position is nothing / when robot is not placed

TESTS:
- added tests to check MOVE, LEFT, RIGHT, REPORT actions are ignore when robot is not placed
- For RIGHT and LEFT tests, group `turn multiple times` tests into a group